### PR TITLE
issue-39: セッション開始時にずんだもん表示・終了時に消去する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ echo '{"type":"notification","id":"test-3","message":"旧形式テスト"}' | so
 セッションごとに透明・フレームレス・常時最前面のウィンドウを動的生成し画面右下に配置（ウィンドウ数に応じてオフセット）。`windows: Map<session_id, BrowserWindow>` でセッション別に管理。色テーマパレット（green/blue/purple/orange/pink）をセッション順に割り当て、ずんだもん画像のhue-rotateで色相変更。Permission FIFO で到着順管理し、先頭セッションのウィンドウを`screen-saver`レベルで最前面に配置。セッションタイトルは`transcript_path`からtranscript JSONLの最初のユーザーメッセージを抽出して表示（URL除去、50文字以内）。タイムアウトベースGC（30秒間隔チェック、5分間メッセージなしでセッション破棄）。hookの`$PPID`は一時プロセスのためPID生存確認は不可。SessionEnd hookとタイムアウトGCでライフサイクル管理。
 
 ### UDS サーバー (`src/socket-server.js`)
-`/tmp/zundamon-claude.sock` で JSON Lines プロトコルを処理。`sessions: Map<session_id, {pid, cwd, pendingConnections}>` でセッション単位管理。コールバック方式（`onMessage`, `onSessionStart`, `onSessionEnd`, `onPermissionRequest`, `onSessionPermissionsDismiss`, `onAllPermissionsDismiss`）で main.js が適切なウィンドウにルーティング。`session_id` 未設定メッセージは `"default"` にフォールバック。DISMISS は対象セッションのpendingのみクリア。
+`/tmp/zundamon-claude.sock` で JSON Lines プロトコルを処理。`sessions: Map<session_id, {pid, cwd, pendingConnections}>` でセッション単位管理。コールバック方式（`onMessage`, `onSessionStart`, `onSessionEnd`, `onPermissionRequest`, `onSessionPermissionsDismiss`, `onAllPermissionsDismiss`）で main.js が適切なウィンドウにルーティング。`session_id` 未設定メッセージは `"default"` にフォールバック。DISMISS ハンドラは `getOrCreateSession` を呼ぶため、UserPromptSubmit hook での最初の dismiss メッセージでセッションが自動作成される。
 
 ### プロトコル (`src/protocol.js`)
 メッセージ型（`PERMISSION_REQUEST`, `NOTIFICATION`, `STOP`, `DISMISS`, `SESSION_END`）の定義とパース/シリアライズ。`session_id` 未設定時は `"default"` にフォールバック。
@@ -47,7 +47,7 @@ echo '{"type":"notification","id":"test-3","message":"旧形式テスト"}' | so
 吹き出し UI の表示制御。Permission はキューベースで複数同時保持し順次表示（待ち件数表示付き）。許可/拒否ボタン付き（590秒タイムアウト）。`permission_suggestions` がある場合は「次回から聞かないのだ」ボタンを表示。セッションタイトル（最初のユーザーメッセージ）を足元に表示（フォールバック: cwdのディレクトリ名）。CSS変数で色テーマを適用。キャラクターのドラッグ&ドロップによるウィンドウ移動、右クリックコンテキストメニュー（再起動・このずんだもんを終了・終了）に対応。
 
 ### Hook スクリプト (`hooks/`)
-全スクリプトでstdin JSONから `session_id`/`cwd`/`transcript_path` を抽出し、`$PPID` を pid としてUDSメッセージに含める。`zundamon-permission.sh` は Python3 で安全にパースし socat でブロッキング送信（590秒タイムアウト）。`zundamon-notify.sh` は permission_prompt 由来の通知をフィルタリング。`zundamon-dismiss.sh`/`zundamon-pre-dismiss.sh` はセッション単位でdismiss。`zundamon-session-end.sh` は SessionEnd hook でセッション終了を通知。
+全スクリプトでstdin JSONから `session_id`/`cwd`/`transcript_path` を抽出し、`$PPID` を pid としてUDSメッセージに含める。`zundamon-permission.sh` は Python3 で安全にパースし socat でブロッキング送信（590秒タイムアウト）。`zundamon-notify.sh` は permission_prompt 由来の通知をフィルタリング。`zundamon-dismiss.sh`/`zundamon-pre-dismiss.sh` はセッション単位でdismiss（`zundamon-pre-dismiss.sh` は `cwd`/`pid`/`transcript_path` も含めて送信し、セッション作成のトリガーにもなる）。`zundamon-session-end.sh` は SessionEnd hook でセッション終了を通知。`~/.claude/settings.json` に SessionEnd hook を登録済み。
 
 ## 参考プロジェクト
 

--- a/src/socket-server.js
+++ b/src/socket-server.js
@@ -182,6 +182,8 @@ class SocketServer {
       }
 
       case MESSAGE_TYPES.DISMISS: {
+        // セッションが未作成なら作成する（UserPromptSubmitでのセッション開始検知）
+        this.getOrCreateSession(sessionId, msg);
         // 対象セッションのpendingのみクリア
         const session = this.sessions.get(sessionId);
         if (session) {


### PR DESCRIPTION
## Summary
- DISMISSハンドラで `getOrCreateSession` を呼ぶことで、UserPromptSubmit hookの最初のdismissメッセージでセッションが自動作成されるようにした
- `zundamon-pre-dismiss.sh` に `cwd`/`pid`/`transcript_path` を含めるよう修正（セッション作成に必要な情報）
- `~/.claude/settings.json` に SessionEnd hookを登録し、セッション終了時にずんだもんが消えるようにした

## Test plan
- [ ] ずんだもんアプリを再起動
- [ ] 新しいClaude Codeセッションを開始 → 最初のメッセージ送信時にずんだもんが表示されること
- [ ] `/exit` でセッション終了 → ずんだもんが消えること

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)