### PR TITLE
issue-51: Permission Request吹き出し消失問題の調査用デバッグログを追加

### DIFF
--- a/renderer/renderer.js
+++ b/renderer/renderer.js
@@ -143,12 +143,14 @@ window.electronAPI.onSessionInfo((info) => {
 
 // Permission Request
 window.electronAPI.onPermissionRequest((data) => {
+  console.log('[DEBUG] onPermissionRequest:', JSON.stringify({ id: data.id, tool_name: data.tool_name, queueBefore: permissionQueue.length }));
   permissionQueue.push(data);
   displayCurrentPermission();
 });
 
 // Notification
 window.electronAPI.onNotification((data) => {
+  console.log('[DEBUG] onNotification:', JSON.stringify({ message: data.message, queueLength: permissionQueue.length, bubbleVisible }));
   // Permissionキューがある場合はNotificationを表示しない（キューを維持）
   if (permissionQueue.length > 0) return;
   showBubble(data.message || '通知なのだ！');
@@ -156,6 +158,7 @@ window.electronAPI.onNotification((data) => {
 
 // Stop (入力待ち)
 window.electronAPI.onStop((data) => {
+  console.log('[DEBUG] onStop:', JSON.stringify({ message: data.message, queueLength: permissionQueue.length, bubbleVisible }));
   // Permissionキューがある場合はStopを表示しない（キューを維持）
   if (permissionQueue.length > 0) return;
   showBubble(data.message || '入力を待っているのだ！');
@@ -213,7 +216,9 @@ btnClose.addEventListener('click', () => {
 // コンソール側で許可/拒否された場合、該当IDをキューから除去
 window.electronAPI.onPermissionDismissed((data) => {
   const wasFirst = permissionQueue.length > 0 && permissionQueue[0].id === data.id;
+  const queueBefore = permissionQueue.map((item) => item.id);
   permissionQueue = permissionQueue.filter((item) => item.id !== data.id);
+  console.log('[DEBUG] onPermissionDismissed:', JSON.stringify({ dismissedId: data.id, wasFirst, queueBefore, queueAfter: permissionQueue.map((item) => item.id) }));
 
   if (wasFirst) {
     // 先頭が除去された場合、次を表示
@@ -226,6 +231,7 @@ window.electronAPI.onPermissionDismissed((data) => {
 
 // dismiss メッセージで吹き出しを閉じる（キュー全クリア）
 window.electronAPI.onDismissBubble(() => {
+  console.log('[DEBUG] onDismissBubble:', JSON.stringify({ queueBefore: permissionQueue.map((item) => item.id), bubbleVisible }));
   permissionQueue = [];
   if (bubbleVisible) {
     hideBubble();

--- a/src/socket-server.js
+++ b/src/socket-server.js
@@ -121,6 +121,7 @@ class SocketServer {
         for (const [sessionId, session] of this.sessions) {
           for (const [id, s] of session.pendingConnections) {
             if (s === socket) {
+              console.log(`[DEBUG][SOCKET_CLOSE] Socket closed for pending permission id=${id}, session=${sessionId}`);
               session.pendingConnections.delete(id);
               if (this.callbacks.onMessage) {
                 this.callbacks.onMessage(sessionId, 'permission-dismissed', { id });
@@ -186,7 +187,10 @@ class SocketServer {
         // 対象セッションのpendingのみクリア
         const session = this.sessions.get(sessionId);
         if (session) {
+          const pendingIds = [...session.pendingConnections.keys()];
+          console.log(`[DEBUG][DISMISS] sessionId=${sessionId}, pendingConnections=${JSON.stringify(pendingIds)}`);
           for (const [id, s] of session.pendingConnections) {
+            console.log(`[DEBUG][DISMISS] Dismissing permission id=${id} for session=${sessionId}`);
             if (this.callbacks.onMessage) {
               this.callbacks.onMessage(sessionId, 'permission-dismissed', { id });
             }
@@ -195,6 +199,7 @@ class SocketServer {
           session.pendingConnections.clear();
         }
         // Notification/Stopの吹き出しも閉じる
+        console.log(`[DEBUG][DISMISS] Sending dismiss-bubble for session=${sessionId}`);
         if (this.callbacks.onMessage) {
           this.callbacks.onMessage(sessionId, 'dismiss-bubble', {});
         }


### PR DESCRIPTION
## Summary
- renderer.js の各イベントハンドラ（onPermissionRequest, onNotification, onStop, onPermissionDismissed, onDismissBubble）にデバッグログを追加
- socket-server.js の DISMISS ハンドラとソケット close イベントにデバッグログを追加
- issue #51 のタイトル・本文を Permission Request の問題として更新

## Test plan
- [ ] アプリ起動後、Permission Request を発生させてコンソールログを確認
- [ ] 吹き出しが一瞬で消える現象が再現した際のログから原因を特定

close #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)