### PR TITLE
issue-53: 吹き出し表示中の透過部分クリックスルーを修正

### DIFF
--- a/renderer/renderer.js
+++ b/renderer/renderer.js
@@ -21,24 +21,17 @@ let bubbleVisible = false;
 
 // マウスがUI要素に乗ったらクリックスルーを解除、離れたら復活
 function setupMouseForwarding() {
-  document.addEventListener('mouseenter', () => {
-    // 吹き出し表示中はクリックスルーを解除
-    if (bubbleVisible) {
-      window.electronAPI.setIgnoreMouse(false);
-    }
-  });
-
   document.addEventListener('mouseleave', () => {
     window.electronAPI.setIgnoreMouse(true);
   });
 
-  // mousemoveでもチェック（forward: trueでmousemoveが来る）
+  // mousemoveでチェック（forward: trueでmousemoveが来る）
   document.addEventListener('mousemove', (e) => {
     const isOverCharacter = isPointInElement(e, character);
     const isOverBubble = bubbleVisible && isPointInElement(e, bubble);
     if (isOverCharacter || isOverBubble) {
       window.electronAPI.setIgnoreMouse(false);
-    } else if (!bubbleVisible) {
+    } else {
       window.electronAPI.setIgnoreMouse(true);
     }
   });
@@ -71,9 +64,6 @@ function showBubble(text, showButtons = false, { html = false } = {}) {
   }
 
   bubble.classList.remove('hidden');
-
-  // 吹き出し表示中はクリックスルーを解除
-  window.electronAPI.setIgnoreMouse(false);
 }
 
 function hideBubble() {


### PR DESCRIPTION
## Summary
- 吹き出し表示中にウィンドウの透過部分をクリックしても下のアプリにクリックが届かない問題を修正
- `mouseenter`での無条件クリックスルー解除を削除し、`mousemove`の位置判定に統一
- `showBubble()`内の一律`setIgnoreMouse(false)`を削除

## Test plan
- [ ] 吹き出し非表示時: 透過部分クリック → 下のアプリに届く
- [ ] 吹き出し表示時: 透過部分クリック → 下のアプリに届く
- [ ] 吹き出し表示時: 吹き出し/キャラクタークリック → ウィンドウが受け取る
- [ ] Permissionのボタンクリックが動作する
- [ ] ドラッグでウィンドウ移動が動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)