### PR TITLE
restart-script: アプリ再起動スクリプトを追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ echo '{"type":"notification","id":"test-3","message":"旧形式テスト"}' | so
 ### 動作確認時のアプリ再起動
 コード変更後に動作確認が必要な場合は、ユーザーに確認せずずんだもんアプリを再起動すること：
 ```bash
-pkill -f "electron \." 2>/dev/null; sleep 1; npm start &
+./scripts/restart.sh
 ```
 
 ### コミット後のPR作成

--- a/scripts/restart.sh
+++ b/scripts/restart.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# ずんだもんアプリを再起動するスクリプト
+cd "$(dirname "$0")/.."
+pkill -f "electron \." 2>/dev/null
+sleep 1
+npm start &


### PR DESCRIPTION
## Summary
- `scripts/restart.sh` を追加し、アプリ再起動コマンドをスクリプト化
- CLAUDE.md の再起動手順をスクリプト呼び出しに更新
- `.claude/settings.local.json` でスクリプト実行を許可設定することで、再起動時の許可プロンプトを不要に

## Test plan
- [x] `./scripts/restart.sh` でアプリが正常に再起動されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)