### PR TITLE
issue-21: 吹き出しの実際の高さに応じてウィンドウを動的に拡張

### DIFF
--- a/main.js
+++ b/main.js
@@ -187,13 +187,14 @@ function setupIPC() {
   const EXPANDED_WIN_HEIGHT = 550;
   const COMPACT_WIN_HEIGHT = 340;
 
-  ipcMain.on('expand-window', (event) => {
+  ipcMain.on('expand-window', (event, targetHeight) => {
     const win = BrowserWindow.fromWebContents(event.sender);
     if (win && !win.isDestroyed()) {
       const bounds = win.getBounds();
-      const diff = EXPANDED_WIN_HEIGHT - bounds.height;
+      const expandTo = Math.min(targetHeight || EXPANDED_WIN_HEIGHT, EXPANDED_WIN_HEIGHT);
+      const diff = expandTo - bounds.height;
       if (diff > 0) {
-        win.setBounds({ x: bounds.x, y: bounds.y - diff, width: bounds.width, height: EXPANDED_WIN_HEIGHT });
+        win.setBounds({ x: bounds.x, y: bounds.y - diff, width: bounds.width, height: expandTo });
       }
     }
   });

--- a/preload.js
+++ b/preload.js
@@ -17,7 +17,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   onShortcutAlwaysAllow: (callback) => ipcRenderer.on('shortcut-always-allow', () => callback()),
   onHideBubble: (callback) => ipcRenderer.on('hide-bubble', () => callback()),
   // 吹き出し表示時のウィンドウ拡張/縮小
-  expandWindow: () => ipcRenderer.send('expand-window'),
+  expandWindow: (targetHeight) => ipcRenderer.send('expand-window', targetHeight),
   compactWindow: () => ipcRenderer.send('compact-window'),
   // マルチセッション用
   onSessionInfo: (callback) => ipcRenderer.on('session-info', (_event, data) => callback(data)),

--- a/renderer/renderer.js
+++ b/renderer/renderer.js
@@ -78,7 +78,6 @@ function showBubble(text, showButtons = false, { html = false } = {}) {
     bubbleText.textContent = text;
   }
   bubbleVisible = true;
-  window.electronAPI.expandWindow();
 
   if (showButtons) {
     bubbleButtons.classList.remove('hidden');
@@ -87,6 +86,14 @@ function showBubble(text, showButtons = false, { html = false } = {}) {
   }
 
   bubble.classList.remove('hidden');
+
+  // DOM描画後に吹き出しの実際の高さを測ってウィンドウを拡張
+  requestAnimationFrame(() => {
+    const bubbleHeight = bubble.offsetHeight;
+    // 吹き出しはbottom:310pxに配置。必要なウィンドウ高さ = 310 + 吹き出し高さ + マージン
+    const neededHeight = 310 + bubbleHeight + 20;
+    window.electronAPI.expandWindow(neededHeight);
+  });
 
   // 吹き出し表示中は作業中スピナーを止める
   pauseStatusSpinner();


### PR DESCRIPTION
## Summary
- 吹き出し表示時のウィンドウ拡張を固定550pxから、DOM描画後の実際の高さに応じた動的拡張に変更
- 小さい吹き出しのときは必要最小限だけ拡張するため、上方向のドラッグ範囲がさらに改善

Related: #21

## Test plan
- [ ] 小さい吹き出し（Stop通知等）表示時に、大きく上方向にドラッグできることを確認
- [ ] 大きい吹き出し（Permission等）表示時にも吹き出しが正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)