### PR TITLE
blog-zundamon-notify: ブログ記事の下書きを追加

### DIFF
--- a/docs/blog-zundamon-notify.md
+++ b/docs/blog-zundamon-notify.md
@@ -1,5 +1,7 @@
 # Claude Codeの通知、ずんだもんにやらせてみた - zundamon-notify の紹介
 
+リポジトリはこちらで公開しています: [kasei-san/zundamon-notify](https://github.com/kasei-san/zundamon-notify)
+
 ## はじめに
 
 [前回の記事](https://techblog.lclco.com/entry/2026/03/06/121928)では、Claude Code を軸にした一日の業務フロー（朝の立ち上げからセッション引き継ぎまで）を紹介しました。その中の「hookによる自動化の積み重ね」セクションで、hook を使った gh コマンドの操作履歴記録や PR のブラウザ自動オープンなどを紹介しましたが、今回はこの **hook の仕組みをさらに活用**して作った、ちょっと変わったデスクトップ通知アプリ「**zundamon-notify**」を紹介します。


### PR DESCRIPTION
## Summary
- zundamon-notify を紹介するテックブログ記事の下書きを `docs/blog-zundamon-notify.md` に追加
- 前回の `~/.claude` 記事と同様のスタイル（問題→解決→コード例の流れ）で構成
- 仕組み、主な機能5つ、セットアップ手順、開発裏話をカバー

## レビューポイント
- 記事の構成・流れは適切か
- 技術的な説明の粒度は適切か
- 追加したい内容・削除したい内容はあるか
- スクリーンショットの追加が必要な箇所はあるか

Generated with [Claude Code](https://claude.com/claude-code)