### PR TITLE
fix-codex-untrusted-dir: gitリポジトリ外cwdでのcodex UNKNOWN連続を修正

### DIFF
--- a/hooks/auto-approve.py
+++ b/hooks/auto-approve.py
@@ -414,7 +414,7 @@ def judge_with_codex(prompt):
     debug_log = Path.home() / ".config" / "zundamon-notify" / "auto-approve-debug.log"
     try:
         result = subprocess.run(
-            ["perl", "-e", "alarm 10; exec @ARGV", codex_path, "exec", "--ephemeral", "-"],
+            ["perl", "-e", "alarm 10; exec @ARGV", codex_path, "exec", "--ephemeral", "--skip-git-repo-check", "-"],
             input=prompt,
             capture_output=True,
             text=True,


### PR DESCRIPTION
## Summary
- codex呼び出しに `--skip-git-repo-check` フラグを追加
- gitリポジトリ外のcwd（`~/work` 等）からhookが発火した場合に、codexが `Not inside a trusted directory` エラーで失敗しUNKNOWN判定が連続する問題を修正
- codexはリスク判定のみに使用しており、git操作は行わないためチェック不要

## 原因
- `gh search` コマンド等がcwd `/Users/kobayashi/work`（gitリポジトリではない）で実行された際、codexのtrustedディレクトリチェックに引っかかり `returncode=1` + 空stdout → UNKNOWN判定になっていた

## Test plan
- [x] デバッグログで原因確認済み
- [ ] gitリポジトリ外のcwdからPermissionリクエストが来た場合にcodex判定が正常動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)