### PR TITLE
auto-approve-stderr-tail: codexデバッグログのstderr切り捨てを末尾優先に変更

### DIFF
--- a/hooks/auto-approve.py
+++ b/hooks/auto-approve.py
@@ -426,7 +426,7 @@ def judge_with_codex(prompt):
             "codex_path": codex_path,
             "returncode": result.returncode,
             "stdout": result.stdout[:500],
-            "stderr": result.stderr[:500],
+            "stderr": result.stderr[-2000:],
         })
         # returncodeに関わらずstdoutをパース（SIGALRM=-14でも応答が出力済みの場合がある）
         output = result.stdout.strip() if result.stdout else ""


### PR DESCRIPTION
## Summary
- auto-approve.py のデバッグログで `result.stderr[:500]` だと codex のヘッダ（workdir / model / session id 等）でバッファを使い切ってしまい、肝心のエラー本文がログに残らない問題を修正
- `[-2000:]` に変更し、末尾のエラーメッセージを確実に拾えるようにした

## Background
2026-05-19 に codex 判定が 3 回連続で失敗する事象が発生。`auto-approve-debug.log` を見ても以下のような途中で切れた stderr しか残っておらず原因特定に時間がかかった：

```
OpenAI Codex v0.120.0 (research preview)
--------
workdir: /Users/kobayashi/work/...
model: gpt-5.2-codex
...
Rules for RISK:
- AWS/GCP   ← ここで切れる
```

実際に codex を手で叩いたら末尾に `400 invalid_request_error: 'gpt-5.2-codex' is not supported when using Codex with a ChatGPT account` が出ていた。**エラーは stderr の末尾に出るので、先頭ではなく末尾を残すべき**。

## Test plan
- [x] 構文確認: `python3 -c "import ast; ast.parse(open('hooks/auto-approve.py').read())"` (済)
- [x] codex 実行リトライで `stderr` 末尾の `ERROR: {"type":"error",...}` がログに残ることを次回障害時に確認できる状態にした