### PR TITLE
fix-codex-model-gpt55: codex LLM判定モデルを gpt-5.5 に固定する

### DIFF
--- a/hooks/auto-approve.py
+++ b/hooks/auto-approve.py
@@ -405,16 +405,20 @@ Description: {description}
 Your assessment (SAFE or RISK with summary):"""
 
 
-def judge_with_codex(prompt):
+DEFAULT_CODEX_MODEL = "gpt-5.5"
+
+
+def judge_with_codex(prompt, codex_model=None):
     """codex CLIでリスク判定を実行。(判定, 概要)のタプルを返す。エラー時は(None, None)。"""
     codex_path = shutil.which("codex")
     if not codex_path:
         return None, None
 
+    model = codex_model or DEFAULT_CODEX_MODEL
     debug_log = Path.home() / ".config" / "zundamon-notify" / "auto-approve-debug.log"
     try:
         result = subprocess.run(
-            ["perl", "-e", "alarm 10; exec @ARGV", codex_path, "exec", "--ephemeral", "--skip-git-repo-check", "-m", "gpt-5.5", "-"],
+            ["perl", "-e", "alarm 10; exec @ARGV", codex_path, "exec", "--ephemeral", "--skip-git-repo-check", "-m", model, "-"],
             input=prompt,
             capture_output=True,
             text=True,
@@ -517,7 +521,8 @@ def main():
                 custom_rules = [custom_rules]
 
             prompt = build_prompt(tool_name, tool_input, cwd, description, custom_rules)
-            judgment, summary = judge_with_codex(prompt)
+            codex_model = auto_approve.get("codex_model")
+            judgment, summary = judge_with_codex(prompt, codex_model=codex_model)
 
     # ログ記録（SAFE/RISK両方）
     log_path_str = auto_approve.get("log_file", "")

--- a/hooks/auto-approve.py
+++ b/hooks/auto-approve.py
@@ -414,7 +414,7 @@ def judge_with_codex(prompt):
     debug_log = Path.home() / ".config" / "zundamon-notify" / "auto-approve-debug.log"
     try:
         result = subprocess.run(
-            ["perl", "-e", "alarm 10; exec @ARGV", codex_path, "exec", "--ephemeral", "--skip-git-repo-check", "-"],
+            ["perl", "-e", "alarm 10; exec @ARGV", codex_path, "exec", "--ephemeral", "--skip-git-repo-check", "-m", "gpt-5.5", "-"],
             input=prompt,
             capture_output=True,
             text=True,


### PR DESCRIPTION
## 問題

`auto-approve.py` がcodex CLIでLLM判定する際、`~/.codex/config.toml` に設定されたデフォルトモデル `gpt-5.3-codex` を使っていた。

このモデルはChatGPTアカウントではサポートされなくなっており、呼び出しが `returncode: 1` / stdout空 で失敗し続けていた。結果として自動許可が動かず UNKNOWN 判定が連続していた。

## 修正

`codex exec` に `-m gpt-5.5` を明示的に指定することで、ChatGPTアカウントで利用可能なモデルに固定する。

## 確認

```
$ echo '{"type":"permission_request",...,"tool_name":"Bash","tool_input":{"command":"ls /tmp"},...}' | ZUNDAMON_HOOK_DATA=... python3 hooks/auto-approve.py
SAFE	ls /tmpを実行するのだ
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)